### PR TITLE
Fix: Remove unused ->hasViews() from service provider

### DIFF
--- a/src/SimplestatsPluginServiceProvider.php
+++ b/src/SimplestatsPluginServiceProvider.php
@@ -13,7 +13,6 @@ class SimplestatsPluginServiceProvider extends PackageServiceProvider
     {
         $package
             ->name(static::$name)
-            ->hasConfigFile()
-            ->hasViews();
+            ->hasConfigFile();
     }
 }


### PR DESCRIPTION
Closes #1 

## Problem
 
The `configurePackage()` method in `SimplestatsPluginServiceProvider` calls `->hasViews()`, which tells `spatie/laravel-package-tools` to register a view namespace pointing at `resources/views`. However, this directory does not exist in the package — the plugin renders everything through Filament's Livewire widget system and has no Blade views of its own.
 
This causes `php artisan view:cache` to throw a `DirectoryNotFoundException` during deployment, since Symfony Finder tries to scan the non-existent directory:
 
```
In Finder.php line 648:
 
  The "vendor/simplestats-io/filament-plugin/src/../resources/views"
  directory does not exist.
```
 
Any deployment pipeline that runs `view:cache` (e.g. Laravel Forge's default deploy script) will fail on this.
 
## Fix
 
Remove the `->hasViews()` call. It's leftover boilerplate from the Filament plugin skeleton and has no functional impact — the plugin doesn't use package-level Blade views.
 
## Alternative considered
 
Adding an empty `resources/views/.gitkeep` would also fix the crash, but registering a view namespace that will never be used is unnecessary overhead. Removing the call is cleaner.
 